### PR TITLE
fix(manipulator): 关闭拖拽代理碰撞，消除垃圾约束

### DIFF
--- a/orca_gym/core/euler/mujoco_sim_core.py
+++ b/orca_gym/core/euler/mujoco_sim_core.py
@@ -15,6 +15,41 @@ import numpy as np
 from orca_gym.core.euler.orca_gym_data_view import OrcaGymDataView
 
 
+_ACTOR_MANIPULATOR_BODY_NAMES = (
+    "ORCA_MANIPULATOR_a3f5e2d1-7b8c-4f2a-9e6d-1c2b3a4f5d6e_Anchor",
+    "ORCA_MANIPULATOR_a3f5e2d1-7b8c-4f2a-9e6d-1c2b3a4f5d6e_dummy",
+    "ActorManipulator_Anchor",
+    "ActorManipulator_dummy",
+)
+
+
+def disable_actor_manipulator_collision(model: mujoco.MjModel) -> int:
+    """
+    关闭 ActorManipulator 拖拽代理所有几何体的碰撞掩码（contype=conaffinity=0）。
+
+    拖拽/抓取依赖 mocap anchor 与 weld 等号约束，与接触完全无关，故关闭碰撞不影响功能；
+    但可消除 AR-001 中该代理埋地/远端碰撞体与无限平面贯产生的垃圾约束（junk efc）行。
+
+    Args:
+        model: 原始 mujoco.MjModel。
+
+    Returns:
+        被修改的 geom 数量（用于日志/断言）。
+    """
+    n_disabled = 0
+    for body_name in _ACTOR_MANIPULATOR_BODY_NAMES:
+        body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, body_name)
+        if body_id < 0:
+            continue
+        for gid in range(model.ngeom):
+            if model.geom_bodyid[gid] == body_id:
+                if model.geom_contype[gid] != 0 or model.geom_conaffinity[gid] != 0:
+                    model.geom_contype[gid] = 0
+                    model.geom_conaffinity[gid] = 0
+                    n_disabled += 1
+    return n_disabled
+
+
 class MuJoCoSimCore:
     """MuJoCo 仿真核心，持有 _mjModel/_mjData。
 
@@ -55,6 +90,19 @@ class MuJoCoSimCore:
         """
         self._mjModel = mujoco.MjModel.from_xml_path(model_xml_path)
         self._mjData = mujoco.MjData(self._mjModel)
+        # AR-001：模型加载后关闭 ActorManipulator 拖拽代理的碰撞掩码，
+        # 消除其埋地/远端碰撞体与无限平面贯产生的垃圾约束行（不影响 mocap weld 拖拽）。
+        self.disable_actor_manipulator_collision()
+
+    def disable_actor_manipulator_collision(self) -> int:
+        """关闭 ActorManipulator 拖拽代理几何体的碰撞掩码（可随时重试/重断言）。
+
+        Returns:
+            本次被修改的 geom 数量。
+        """
+        if self._mjModel is None:
+            return 0
+        return disable_actor_manipulator_collision(self._mjModel)
 
     def reset_data(self) -> None:
         """重置 MjData 到初始状态（mj_resetData）。

--- a/orca_gym/core/euler/orca_gym_euler.py
+++ b/orca_gym/core/euler/orca_gym_euler.py
@@ -694,3 +694,15 @@ class OrcaGymEuler:
     def set_equality_solimp(self, eq_idx: int, solimp) -> None:
         """设置等式约束 solver impedance 参数（委托 SimCore）。"""
         object.__getattribute__(self, "_sim").set_equality_solimp(eq_idx, solimp)
+
+    # --- AR-001：拖拽代理碰撞掩码关闭（委托 SimCore，不暴露 _mjModel）---
+
+    def disable_actor_manipulator_collision(self) -> int:
+        """关闭 ActorManipulator 拖拽代理几何体的碰撞掩码（委托 SimCore）。
+
+        模型加载时（init_simulation）已自动执行；本方法供环境在需要时重断言。
+
+        Returns:
+            本次被修改的 geom 数量。
+        """
+        return object.__getattribute__(self, "_sim").disable_actor_manipulator_collision()

--- a/orca_gym/core/orca_gym_local.py
+++ b/orca_gym/core/orca_gym_local.py
@@ -28,6 +28,43 @@ from orca_gym.core.orca_gym import OrcaGymBase
 from orca_gym.utils.dir_utils import cleanup_zombie_locks, file_lock
 
 import mujoco
+
+# 覆盖新旧两种命名：UUID 化 ORCA_MANIPULATOR_<uuid> 与旧版 ActorManipulator。
+_ACTOR_MANIPULATOR_BODY_NAMES = (
+    "ORCA_MANIPULATOR_a3f5e2d1-7b8c-4f2a-9e6d-1c2b3a4f5d6e_Anchor",
+    "ORCA_MANIPULATOR_a3f5e2d1-7b8c-4f2a-9e6d-1c2b3a4f5d6e_dummy",
+    "ActorManipulator_Anchor",
+    "ActorManipulator_dummy",
+)
+
+
+def disable_actor_manipulator_collision(model: mujoco.MjModel) -> int:
+    """
+    关闭 ActorManipulator 拖拽代理所有几何体的碰撞掩码（contype=conaffinity=0）。
+
+    拖拽/抓取依赖 mocap anchor 与 weld 等号约束，与接触完全无关，故关闭碰撞不影响功能；
+    但可消除 AR-001 中该代理埋地/远端碰撞体与无限平面贯产生的垃圾约束（junk efc）行。
+
+    Args:
+        model: 原始 mujoco.MjModel。
+
+    Returns:
+        被修改的 geom 数量（用于日志/断言）。
+    """
+    n_disabled = 0
+    for body_name in _ACTOR_MANIPULATOR_BODY_NAMES:
+        body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, body_name)
+        if body_id < 0:
+            continue
+        for gid in range(model.ngeom):
+            if model.geom_bodyid[gid] == body_id:
+                if model.geom_contype[gid] != 0 or model.geom_conaffinity[gid] != 0:
+                    model.geom_contype[gid] = 0
+                    model.geom_conaffinity[gid] = 0
+                    n_disabled += 1
+    return n_disabled
+
+
 from scipy.spatial.transform import Rotation as R
 
 
@@ -305,6 +342,12 @@ class OrcaGymLocal(OrcaGymBase):
         self._xml_path = model_xml_path  # 保存 XML 路径，用于后续解析 mesh 文件路径
         self._mjModel = mujoco.MjModel.from_xml_path(model_xml_path)
         self._mjData = mujoco.MjData(self._mjModel)
+
+        # AR-001：模型加载后关闭 ActorManipulator 拖拽代理的碰撞掩码，消除其埋地/远端
+        # 碰撞体与无限平面贯产生的垃圾约束行（不影响 mocap weld 拖拽）。
+        n = disable_actor_manipulator_collision(self._mjModel)
+        if n > 0:
+            _logger.info(f"disabled collision on {n} ActorManipulator geom(s).")
 
         size_model = mujoco.mj_sizeModel(self._mjModel)
         _logger.debug(f"size_model: {size_model}")

--- a/orca_gym/environment/euler/orca_gym_euler_env.py
+++ b/orca_gym/environment/euler/orca_gym_euler_env.py
@@ -238,6 +238,13 @@ class OrcaGymEulerEnv(OrcaGymEnvMixin, gym.Env):
                 )
         except Exception as e:
             _logger.warning(f"Failed to resolve anchor mocap body name: {e}")
+        # AR-001：关闭 ActorManipulator 拖拽代理碰撞掩码（init_simulation 已执行，
+        # 此处经公共方法再断言一次，覆盖新/旧 Anchor 命名，保证代理不参与物理碰撞）。
+        try:
+            n = self._gym.disable_actor_manipulator_collision()
+            _logger.info(f"ActorManipulator collision disabled on {n} geom(s).")
+        except Exception as e:
+            _logger.warning(f"failed to disable ActorManipulator collision: {e}")
         return self._gym.model, self._gym.data
 
     def reset_simulation(self) -> None:

--- a/orca_gym/environment/orca_gym_local_env.py
+++ b/orca_gym/environment/orca_gym_local_env.py
@@ -18,7 +18,7 @@ _logger = get_orca_logger()
 from orca_gym import OrcaGymLocal
 from orca_gym.protos.mjc_message_pb2_grpc import GrpcServiceStub 
 from orca_gym.utils.rotations import mat2quat, quat2mat, quat_mul, quat2euler, euler2quat
-from orca_gym.core.orca_gym_local import AnchorType, get_eq_type, CaptureMode
+from orca_gym.core.orca_gym_local import AnchorType, get_eq_type, CaptureMode, disable_actor_manipulator_collision
 
 from orca_gym import OrcaGymModel
 from orca_gym import OrcaGymData
@@ -95,6 +95,11 @@ class OrcaGymLocalEnv(OrcaGymBaseEnv):
             self._anchor_body_id = None
             self._anchor_dummy_body_id = None
             _logger.warning(f"Anchor body {self._anchor_body_name} not found in the model. Actor manipulation is disabled.")
+
+        # 确保任何加载路径下该代理都不参与物理碰撞（拖拽依赖 mocap weld，与接触无关）。
+        if self.gym is not None and hasattr(self.gym, "_mjModel"):
+            n = disable_actor_manipulator_collision(self.gym._mjModel)
+            _logger.info(f"ActorManipulator collision disabled on {n} geom(s).")
 
     def initialize_simulation(
         self,


### PR DESCRIPTION
拖拽功能依赖mocap weld约束，与接触无关，关闭碰撞掩码不影响功能，
但可避免代理埋地或远端碰撞体与无限平面产生无效约束行。